### PR TITLE
bootstrap navbar dropdown fixed

### DIFF
--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -2,7 +2,7 @@
     <p>This is from the footer</p>
 
     <script src="/jquery/dist/jquery.min.js"></script>
-    <script src="/bootstrap/dist/js/bootstrap.min.js"></script>
+    <script src="/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script>
         var getTitle = "<%= title %>";
     </script>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -48,15 +48,17 @@
                   <i class="fas fa-home"></i> About </a>
               </a>
             </li>   
-            <li class="nav-item">
-              <% if (title == "Inventory List") { %>
-                  <a class="nav-link active" href="/inventory/list">
-              <% } else { %>
-                  <a class="nav-link" href="/inventory/list">
-              <% } %>            
-                  <i class="fas fa-home"></i> Inventory List </a>
+            <li class="nav-item dropdown">
+              <a href="#" class="nav-link dropdown-toggle" id="navbarDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+                <i class="fas fa-home"></i> Inventory
               </a>
-            </li>                      
+              <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                <a class="dropdown-item" href="/inventory/add">Add Inventory</a>
+                <a class="dropdown-item" href="/inventory/list">
+                  Inventory List
+                </a>
+              </div>
+          </li>                    
             <li class="nav-item">
               <% if (title == "Users") { %>
                   <a class="nav-link active" href="/users">


### PR DESCRIPTION
For some reason the new version of bootstrap (v5) has other dependencies in order to use the dropdown and that is not included on the .min version of it. I just changed the .min to .bundle.min and it worked out.